### PR TITLE
feat(infrastructure): add DCX nav item with infrastructure child.

### DIFF
--- a/src/encoreNav.json
+++ b/src/encoreNav.json
@@ -71,6 +71,34 @@
         "childVisibility": false
     },
     {
+        "linkText": "DCX",
+        "key": "dcx",
+        "children": [
+            {
+                "href": "/dcx/infrastructure-encore",
+                "linkText": "Infrastructure Manager",
+                "key": "infrastructure",
+                "children": [
+                    {
+                        "href": "/dcx/infrastructure-encore/cells",
+                        "linkText": "Cells",
+                        "key": "cells"
+                    },
+                    {
+                        "href": "/dcx/infrastructure-encore/containers",
+                        "linkText": "Containers",
+                        "key": "containers"
+                    },
+                    {
+                        "href": "/dcx/infrastructure-encore/deployments",
+                        "linkText": "Deployments",
+                        "key": "deployments"
+                    }
+                ]
+            }
+        ]
+    },
+    {
         "href": "/support",
         "linkText": "Support Service",
         "key": "supportService",


### PR DESCRIPTION
This PR adds a new root-level nav item, DCX.  I do not believe the Support Automation (or any of the other items) really captures what this application does - it is used by datacenter techs to configure hardware deployments in the DCs.  I'm open to using another name; maybe there are other projects down the pipeline that I am unaware of.  I know that my team has vague plans to port another app into Encore, the Unified Control Panel, which would also fit into this bucket.

![screen shot 2015-03-30 at 1 45 47 pm](https://cloud.githubusercontent.com/assets/5414922/6903938/22fff790-d6e3-11e4-91a1-f1a732bc1023.png)
